### PR TITLE
Support for reflexive transition callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog for fysom
 --------------------
+* v2.0.1
+  State re-entry or 'reflexive' callbacks (onreenter_state) called when the start and end state of a transition
+  are the same. This is different to the change in v1.1.0 as the new callback type is for a particular state and not
+  a particular event. This allows individual callbacks for reflexive transitions rather than event callbacks
+  with conditional branches to handle both reflexive and non-reflexive transitions.
+  Pull request by [@mattjml](https://github.com/mattjml)
 
 * v2.0.0
   BREAKING CHANGE - Canceling an event by returning `False` from the onbefore<event> callback

--- a/README
+++ b/README
@@ -262,12 +262,13 @@ definition:
 Callbacks
 ---------
 
-4 callbacks are available if your state machine has methods using the
+5 callbacks are available if your state machine has methods using the
 following naming conventions:
 
 -  onbefore\_event\_ - fired before the *event*
 -  onleave\_state\_ - fired when leaving the old *state*
 -  onenter\_state\_ - fired when entering the new *state*
+-  onreenter\_state\_ - fired when reentering the old *state* (a reflexive transition i.e. src == dst)
 -  onafter\_event\_ - fired after the *event*
 
 You can affect the event in 2 ways:

--- a/src/main/python/fysom/__init__.py
+++ b/src/main/python/fysom/__init__.py
@@ -250,14 +250,13 @@ class Fysom(object):
                     self._change_state(e)
                     self._after_event(e)
                 self.transition = _tran
-            else:
-                # If we're already in the target state, we're done with the event
-                self._after_event(e)
 
-            # Hook to perform asynchronous transition.
-            if self._leave_state(e) is not False:
-                if hasattr(self, 'transition'):
+                # Hook to perform asynchronous transition.
+                if self._leave_state(e) is not False:
                     self.transition()
+            else:
+                self._reenter_state(e)
+                self._after_event(e)
 
         fn.__name__ = event
         fn.__doc__ = ("Event handler for an {event} event. This event can be " +
@@ -300,6 +299,15 @@ class Fysom(object):
             if hasattr(self, fnname):
                 return getattr(self, fnname)(e)
 
+    def _reenter_state(self, e):
+        '''
+            Executes the callback for onreenter_state_.
+            This allows callbacks following reflexive transitions (i.e. where src == dst)
+        '''
+        fnname = 'onreenter' + e.dst
+        if hasattr(self, fnname):
+            return getattr(self, fnname)(e)
+    
     def _change_state(self, e):
         '''
             A general change state callback. This gets triggered at the time of state transition.

--- a/src/unittest/python/test_callbacks.py
+++ b/src/unittest/python/test_callbacks.py
@@ -118,6 +118,12 @@ class FysomCallbackTests(unittest.TestCase):
     def on_enter_bared(self, e):
         self.enter_bared_event = e
 
+    def on_reenter_fooed(self, e):
+        self.reenter_fooed_event = e
+
+    def on_reenter_bared(self, e):
+        self.reenter_bared_event = e
+
     def on_leave_sleeping(self, e):
         self.leave_sleeping_event = e
 
@@ -131,7 +137,9 @@ class FysomCallbackTests(unittest.TestCase):
             'initial': 'sleeping',
             'events': [
                 {'name': 'foo', 'src': 'sleeping', 'dst': 'fooed'},
+                {'name': 'foo', 'src': 'fooed', 'dst': 'fooed'},
                 {'name': 'bar', 'src': 'fooed', 'dst': 'bared'},
+                {'name': 'bar', 'src': 'bared', 'dst': 'bared'},
                 {'name': 'baz', 'src': 'bared', 'dst': 'bazed'},
                 {'name': 'wait', 'src': 'sleeping', 'dst': 'waiting'}
             ],
@@ -144,6 +152,8 @@ class FysomCallbackTests(unittest.TestCase):
                 'onbeforewait': self.before_wait,
                 'onenterfooed': self.on_enter_fooed,
                 'onenterbared': self.on_enter_bared,
+                'onreenterfooed': self.on_reenter_fooed,
+                'onreenterbared': self.on_reenter_bared,
                 'onleavesleeping': self.on_leave_sleeping,
                 'onleavefooed': self.on_leave_fooed
             }
@@ -198,6 +208,21 @@ class FysomCallbackTests(unittest.TestCase):
             hasattr(self, 'enter_bared_event'), 'Callback onenterbared did not fire.')
         self.assertTrue(self.enter_bared_event is not None)
         self.assertEqual(self.enter_bared_event.id, 123)
+
+    def test_onreenter_state_callbacks_should_fire_with_keyword_arguments_when_state_transitions_occur(self):
+        self.fsm.foo(attribute='testfail')
+        self.fsm.foo(attribute='testpass')
+        self.assertTrue(
+            hasattr(self, 'reenter_fooed_event'), 'Callback onreenterfooed did not fire.')
+        self.assertTrue(self.reenter_fooed_event is not None)
+        self.assertEqual(self.reenter_fooed_event.attribute, 'testpass')
+
+        self.fsm.bar(id=1234)
+        self.fsm.bar(id=4321)
+        self.assertTrue(
+            hasattr(self, 'reenter_bared_event'), 'Callback onreenterbared did not fire.')
+        self.assertTrue(self.reenter_bared_event is not None)
+        self.assertEqual(self.reenter_bared_event.id, 4321)
 
     def test_onleave_state_callbacks_should_fire_with_keyword_arguments_when_state_transitions_occur(self):
         self.fsm.foo(attribute='test')


### PR DESCRIPTION
Hi,

I added a new type of callback 'called onreenter_event' to handle
reflexive transitions (where src == dst). I used fysom recently and
ended up adding this functionality as as I felt it was missing. 

Admittedly there are other ways to trigger callbacks on reflexive
transitions, but these seemed less clear and more 'hacky'. Feel
free to ask me questions and query anything!

Cheers,
Matt

Commit message below:

"Added onreenter_event callback functionality to handle reflexive
transitions (when source and destination event are the same) in a
concise manner.

This avoids using:
- on event callbacks with conditional branches based on src and dst
    dst state
- specific (and potentially duplicate) events for single reflexive
    transitions"
