### PR TITLE
Don't break the garbage collector

### DIFF
--- a/src/main/python/fysom/__init__.py
+++ b/src/main/python/fysom/__init__.py
@@ -66,8 +66,14 @@ def _weak_callback(func):
         # Don't hold a reference to the object, otherwise we might create
         # a cycle.
         # Reference: http://stackoverflow.com/a/6975682
-        obj_ref  = weakref.ref(func.im_self)
-        func_ref = weakref.ref(func.im_func)
+        try:
+            # Python 2.x case
+            obj_ref  = weakref.ref(func.im_self)
+            func_ref = weakref.ref(func.im_func)
+        except AttributeError:
+            # Python 3.x case
+            obj_ref  = weakref.ref(func.__self__)
+            func_ref = weakref.ref(func.__func__)
         func = None
         def _callback(*args, **kwargs):
             obj = obj_ref()

--- a/src/main/python/fysom/__init__.py
+++ b/src/main/python/fysom/__init__.py
@@ -30,6 +30,7 @@
 import collections
 import weakref
 import types
+import sys
 
 __author__ = 'Mansour Behabadi'
 __copyright__ = 'Copyright 2011, Mansour Behabadi and Jake Gordon'
@@ -66,11 +67,13 @@ def _weak_callback(func):
         # Don't hold a reference to the object, otherwise we might create
         # a cycle.
         # Reference: http://stackoverflow.com/a/6975682
-        try:
+        # Tell coveralls to not cover this if block, as the Python 2.x case
+        # doesn't test the 3.x code and vice versa.
+        if sys.version_info[0] < 3: # pragma: no cover
             # Python 2.x case
             obj_ref  = weakref.ref(func.im_self)
             func_ref = weakref.ref(func.im_func)
-        except AttributeError:
+        else: # pragma: no cover
             # Python 3.x case
             obj_ref  = weakref.ref(func.__self__)
             func_ref = weakref.ref(func.__func__)

--- a/src/unittest/python/test_garbage_collection.py
+++ b/src/unittest/python/test_garbage_collection.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+#
+# fysom - pYthOn Finite State Machine - this is a port of Jake
+#         Gordon's javascript-state-machine to python
+#         https://github.com/jakesgordon/javascript-state-machine
+#
+# Copyright (C) 2011 Mansour Behabadi <mansour@oxplot.com>, Jake Gordon
+#                                        and other contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import unittest
+import gc
+
+from fysom import Fysom
+
+class FysomGarbageCollectionTests(unittest.TestCase):
+
+    def test_should_not_create_circular_ref(self):
+        class MyTestObject(object):
+            def __init__(self):
+                self._states = []
+                self._fsm = Fysom({
+                    'initial': 'green',
+                    'events': [
+                        {'name': 'warn', 'src': 'green', 'dst': 'yellow'},
+                        {'name': 'panic', 'src': 'yellow', 'dst': 'red'},
+                        {'name': 'calm', 'src': 'red', 'dst': 'yellow'},
+                        {'name': 'clear', 'src': 'yellow', 'dst': 'green'}
+                    ],
+                    'callbacks': {
+                        'ongreen':  self._on_green,
+                        'onyellow': self._on_yellow,
+                        'onred':    self._on_red
+                    }
+                })
+
+            def warn(self):
+                self._fsm.warn()
+            def panic(self):
+                self._fsm.panic()
+            def calm(self):
+                self._fsm.calm()
+            def clear(self):
+                self._fsm.clear()
+
+            def _on_green(self, *args, **kwargs):
+                self._states.append('green')
+            def _on_yellow(self, *args, **kwargs):
+                self._states.append('yellow')
+            def _on_red(self, *args, **kwargs):
+                self._states.append('red')
+
+        obj = MyTestObject()
+        obj.warn()
+        obj.clear()
+        del obj
+
+        self.assertEqual(filter(lambda o : isinstance(o, MyTestObject),
+            gc.get_objects()), [])

--- a/src/unittest/python/test_garbage_collection.py
+++ b/src/unittest/python/test_garbage_collection.py
@@ -74,5 +74,5 @@ class FysomGarbageCollectionTests(unittest.TestCase):
         obj.clear()
         del obj
 
-        self.assertEqual(filter(lambda o : isinstance(o, MyTestObject),
-            gc.get_objects()), [])
+        self.assertEqual(list(filter(lambda o : isinstance(o, MyTestObject),
+            gc.get_objects())), [])


### PR DESCRIPTION
In cases where a class has a state machine instance as a member and uses methods for callbacks, the dependencies between the parent class and the child state machine create cycles in the garbage collector.

In order to break these cycles, we modify the state machine to store weak references to the method.  For non-method functions, we can store these safely since the function itself should not hold a reference to the state machine.

This resolves https://github.com/mriehl/fysom/issues/21.