### PR TITLE
_build_event: Ensure `__name__` is a `str`

### DIFF
--- a/src/main/python/fysom/__init__.py
+++ b/src/main/python/fysom/__init__.py
@@ -302,7 +302,7 @@ class Fysom(object):
                 self._reenter_state(e)
                 self._after_event(e)
 
-        fn.__name__ = event
+        fn.__name__ = str(event)
         fn.__doc__ = ("Event handler for an {event} event. This event can be " +
                       "fired if the machine is in {states} states.".format(
                           event=event, states=self._map[event].keys()))

--- a/src/unittest/python/test_unicode_literals.py
+++ b/src/unittest/python/test_unicode_literals.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+#
+# fysom - pYthOn Finite State Machine - this is a port of Jake
+#         Gordon's javascript-state-machine to python
+#         https://github.com/jakesgordon/javascript-state-machine
+#
+# Copyright (C) 2011 Mansour Behabadi <mansour@oxplot.com>, Jake Gordon
+#                                        and other contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from __future__ import unicode_literals
+
+import unittest
+from fysom import Fysom
+
+
+class FysomUnicodeLiterals(unittest.TestCase):
+    def test_it_doesnt_break_with_unicode_literals(self):
+        try:
+            fsm = Fysom({
+                'initial': 'green',
+                'final': 'red',
+                'events': [
+                    {'name': 'warn', 'src': 'green', 'dst': 'yellow'},
+                    {'name': 'panic', 'src': 'yellow', 'dst': 'red'},
+                    {'name': 'calm', 'src': 'red', 'dst': 'yellow'},
+                    {'name': 'clear', 'src': 'yellow', 'dst': 'green'}
+                ]
+            })
+            self.assertTrue(True)
+        except TypeError:
+            self.assertTrue(False)


### PR DESCRIPTION
Python 3 is happy to receive `__name__` objects as Unicode or plain
strings, but Python 2 is not.  This bug shows itself when
`unicode_literals` is imported from calling code.

https://github.com/mriehl/fysom/issues/31