### PR TITLE
support for python 3 cooperative multiple inheritance

### DIFF
--- a/src/main/python/fysom/__init__.py
+++ b/src/main/python/fysom/__init__.py
@@ -99,7 +99,8 @@ class Fysom(object):
         Wraps the complete finite state machine operations.
     '''
 
-    def __init__(self, cfg={}, initial=None, events=None, callbacks=None, final=None):
+    def __init__(self, cfg={}, initial=None, events=None, callbacks=None,
+                 final=None, **kwargs):
         '''
         Construct a Finite State Machine.
 
@@ -133,6 +134,8 @@ class Fysom(object):
         'a'
 
         '''
+        if (sys.version_info[0] >= 3):
+            super().__init__(**kwargs)
         cfg = dict(cfg)
         # override cfg with named arguments
         if "events" not in cfg:


### PR DESCRIPTION
This patch adds support for cooperative multiple inheritance in python 3 while it maintains compatibility for python 2. Backwards compatibility is maintained.